### PR TITLE
Patch that allows the S3 client to use DefaultCredentials with AWS.

### DIFF
--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -58,7 +58,12 @@ public class S3Client {
     }
 
     private AmazonS3Client createAmazonS3Client(AWSCredentials credentials) {
-        AmazonS3Client amazonS3Client = new AmazonS3Client(credentials, createConnectionProperties());
+        AmazonS3Client amazonS3Client;
+        if(credentials != null) {
+            amazonS3Client = new AmazonS3Client(credentials, createConnectionProperties());
+        } else {
+            amazonS3Client = new AmazonS3Client(createConnectionProperties());
+        }
         S3ClientOptions clientOptions = new S3ClientOptions();
         Optional<URI> endpoint = s3ConnectionProperties.getEndpoint();
         if (endpoint.isPresent()) {

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactory.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactory.java
@@ -43,9 +43,9 @@ public class S3ConnectorFactory implements ResourceConnectorFactory {
     @Override
     public ExternalResourceConnector createResourceConnector(ResourceConnectorSpecification connectionDetails) {
         AwsCredentials awsCredentials = connectionDetails.getCredentials(AwsCredentials.class);
-        if(awsCredentials == null) {
-            throw new IllegalArgumentException("AwsCredentials must be set for S3 backed repository.");
-        }
+//        if(awsCredentials == null) {
+//            throw new IllegalArgumentException("AwsCredentials must be set for S3 backed repository.");
+//        }
         return new S3ResourceConnector(new S3Client(awsCredentials, new S3ConnectionProperties()));
     }
 }

--- a/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactoryTest.groovy
+++ b/subprojects/resources-s3/src/test/groovy/org/gradle/internal/resource/transport/aws/s3/S3ConnectorFactoryTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.internal.resource.connector.ResourceConnectorSpecification
 import spock.lang.Specification
 
 class S3ConnectorFactoryTest extends Specification {
-
+/*
     S3ConnectorFactory factory = new S3ConnectorFactory()
     def "fails when no aws credentials provided"() {
         setup:
@@ -35,4 +35,5 @@ class S3ConnectorFactoryTest extends Specification {
         def e = thrown(IllegalArgumentException)
         e.message ==  "AwsCredentials must be set for S3 backed repository."
     }
+*/
 }


### PR DESCRIPTION
(which in turn allows you to use instance credentials instead of user credentials)

To build, run the following:

```
   gradle :resourcesS3:build -x :resourcesS3:integTest
```
